### PR TITLE
Update paperless docker image

### DIFF
--- a/templates/paperless.xml
+++ b/templates/paperless.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>paperless</Name>
-  <Repository>danielquinn/paperless</Repository>
-  <Registry>https://hub.docker.com/r/danielquinn/paperless/</Registry>
+  <Repository>thepaperlessproject/paperless</Repository>
+  <Registry>https://hub.docker.com/r/thepaperlessproject/paperless/</Registry>
   <Network>bridge</Network>
   <Privileged>false</Privileged>
   <Support>https://gitter.im/danielquinn/paperless</Support>


### PR DESCRIPTION
### Changes

* Change docker image to [`thepaperlessproject/paperless/`](https://hub.docker.com/r/thepaperlessproject/paperless/)

### Addressed Issues

`Paperless` is now maintained by the community. Up-to-date docker images are pushed to `thepaperlessproject/paperless`.

* See https://github.com/the-paperless-project/paperless/issues/470
* #18

### Conducted Tests

* Installed the new docker image on my unRaid Server and used it in production - working fine.