### PR TITLE
Change support thread to official unRaid thread

### DIFF
--- a/templates/paperless.xml
+++ b/templates/paperless.xml
@@ -5,7 +5,7 @@
   <Registry>https://hub.docker.com/r/thepaperlessproject/paperless/</Registry>
   <Network>bridge</Network>
   <Privileged>false</Privileged>
-  <Support>https://gitter.im/danielquinn/paperless</Support>
+  <Support>https://forums.unraid.net/topic/87196-support-paperless-docker/</Support>
   <Project>https://github.com/the-paperless-project/paperless</Project>
   <Overview>Index and archive all of your scanned paper documents&#xD;
 [br][br]&#xD;


### PR DESCRIPTION
I created an official unRaid support thread for paperless as people started asking unRaid specific questions in the paperless gitter channel. This pull request changes the support thread.