### PR TITLE
Add more documentation for paperless

### DIFF
--- a/templates/paperless.xml
+++ b/templates/paperless.xml
@@ -4,30 +4,30 @@
   <Repository>thepaperlessproject/paperless</Repository>
   <Registry>https://hub.docker.com/r/thepaperlessproject/paperless/</Registry>
   <Network>bridge</Network>
+  <Shell>bash</Shell>
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/87196-support-paperless-docker/</Support>
   <Project>https://github.com/the-paperless-project/paperless</Project>
-  <Overview>Index and archive all of your scanned paper documents&#xD;
+  <Overview>Index and archive all of your scanned paper documents.&#xD;
 [br][br]&#xD;
-More variables here: https://github.com/the-paperless-project/paperless/blob/master/paperless.conf.example&#xD;
-[br][br]&#xD;
-&#xD;
-RUN: ./manage.py createsuperuser in the container terminal to create the superuser. </Overview>
+For installation instructions see: https://forums.unraid.net/topic/87196-support-paperless-docker/ [br][br]&#xD;
+Paperless Documentation: https://paperless.readthedocs.io/en/latest/[br]&#xD;
+Additional Template Variables: https://github.com/the-paperless-project/paperless/blob/master/paperless.conf.example</Overview>
   <Category>Productivity:</Category>
   <WebUI>http://[IP]:[PORT:8000]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/paperless.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/paperless.png</Icon>
   <PostArgs>runserver 0.0.0.0:8000 --insecure --noreload</PostArgs>
-  <Description>Index and archive all of your scanned paper documents&#xD;
+  <Description>Index and archive all of your scanned paper documents.&#xD;
 [br][br]&#xD;
-More variables here: https://github.com/the-paperless-project/paperless/blob/master/paperless.conf.example&#xD;
-[br][br]&#xD;
-&#xD;
-RUN: ./manage.py createsuperuser in the container terminal to create the superuser. </Description>
+For installation instructions see: https://forums.unraid.net/topic/87196-support-paperless-docker/ [br][br]&#xD;
+Paperless Documentation: https://paperless.readthedocs.io/en/latest/[br]&#xD;
+Additional Template Variables: https://github.com/the-paperless-project/paperless/blob/master/paperless.conf.example</Description>
   <Networking>
     <Mode>bridge</Mode>
     <Publish>
       <Port>
-        <HostPort></HostPort>
+        <HostPort/>
         <ContainerPort>8000</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
@@ -35,25 +35,25 @@ RUN: ./manage.py createsuperuser in the container terminal to create the superus
   </Networking>
   <Data>
     <Volume>
-      <HostDir></HostDir>
+      <HostDir/>
       <ContainerDir>/usr/src/paperless/data</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
     <Volume>
-      <HostDir></HostDir>
+      <HostDir/>
       <ContainerDir>/usr/src/paperless/media</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
     <Volume>
-      <HostDir></HostDir>
+      <HostDir/>
       <ContainerDir>/consume</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
     <Volume>
-      <HostDir></HostDir>
+      <HostDir/>
       <ContainerDir>/export</ContainerDir>
       <Mode>rw</Mode>
-    </Volume>    
+    </Volume>
   </Data>
   <Environment>
     <Variable>
@@ -62,17 +62,41 @@ RUN: ./manage.py createsuperuser in the container terminal to create the superus
       <Mode/>
     </Variable>
     <Variable>
-      <Value>99</Value>
+      <Value/>
+      <Name>PAPERLESS_OCR_LANGUAGE</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value/>
+      <Name>PAPERLESS_FORGIVING_OCR</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value/>
+      <Name>PAPERLESS_INLINE_DOC</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value/>
+      <Name>PAPERLESS_TIME_ZONE</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value/>
       <Name>USERMAP_UID</Name>
       <Mode/>
     </Variable>
   </Environment>
   <Labels/>
-  <Config Name="Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false"></Config>
-  <Config Name="Data" Target="/usr/src/paperless/data" Default="/mnt/user/appdata/paperless/" Mode="rw" Description="Container Path: /usr/src/paperless/data" Type="Path" Display="always" Required="false" Mask="false"></Config>
-  <Config Name="Media" Target="/usr/src/paperless/media" Default="" Mode="rw" Description="Container Path: /usr/src/paperless/media" Type="Path" Display="always" Required="false" Mask="false"></Config>
-  <Config Name="Consumption" Target="/consume" Default="" Mode="rw" Description="Container Path: /consume" Type="Path" Display="always" Required="false" Mask="false"></Config>
-  <Config Name="Export" Target="/export" Default="" Mode="rw" Description="Container Path: /export" Type="Path" Display="always" Required="false" Mask="false"></Config>
-  <Config Name="PAPERLESS_OCR_LANGUAGES" Target="PAPERLESS_OCR_LANGUAGES" Default="" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGES" Type="Variable" Display="always" Required="false" Mask="false"/>
-  <Config Name="PUID" Target="USERMAP_UID" Default="99" Mode="" Description="Container Variable: USERMAP_UID" Type="Variable" Display="always" Required="false" Mask="false">99</Config>
+  <Config Name="Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false"/>
+  <Config Name="Data" Target="/usr/src/paperless/data" Default="/mnt/user/appdata/paperless/data" Mode="rw" Description="Container Path: /usr/src/paperless/data . &#13;&#10;This contains the paperless database. Should be in appdata." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Media" Target="/usr/src/paperless/media" Default="" Mode="rw" Description="Container Path: /usr/src/paperless/media . &#13;&#10;Once consumed, files will be stored here." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Consumption" Target="/consume" Default="" Mode="rw" Description="Container Path: /consume . &#13;&#10;Files placed here will be consumed by paperless." Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Export" Target="/export" Default="" Mode="rw" Description="Container Path: /export . &#13;&#10;Location for files used by the exporter utility.&#13;&#10;See https://paperless.readthedocs.io/en/latest/utilities.html#the-exporter" Type="Path" Display="always" Required="false" Mask="false"/>
+  <Config Name="PAPERLESS_OCR_LANGUAGES" Target="PAPERLESS_OCR_LANGUAGES" Default="eng" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGES . If you want the OCR to recognize other languages in addition to the default English, set this parameter to a space separated list of three-letter language-codes after ISO 639-2/T" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PAPERLESS_OCR_LANGUAGE" Target="PAPERLESS_OCR_LANGUAGE" Default="eng" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGE . Override the language that tesseract will attempt to use when parsing documents. Use a 3-letter language code consistent with ISO 639: https://www.loc.gov/standards/iso639-2/php/code_list.php" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PAPERLESS_FORGIVING_OCR" Target="PAPERLESS_FORGIVING_OCR" Default="false" Mode="" Description="Container Variable: PAPERLESS_FORGIVING_OCR . &#13;&#10;When true, Paperless will consume documents even if the language detection fails." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PAPERLESS_INLINE_DOC" Target="PAPERLESS_INLINE_DOC" Default="false" Mode="" Description="Container Variable: PAPERLESS_INLINE_DOC.&#13;&#10;When true, PDF files will be viewed in the browser. When false (default), PDF files will be downloaded." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PAPERLESS_TIME_ZONE" Target="PAPERLESS_TIME_ZONE" Default="UTC" Mode="" Description="Container Variable: PAPERLESS_TIME_ZONE.&#13;&#10;Override the default UTC time zone. For details see: https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-TIME_ZONE" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PUID" Target="USERMAP_UID" Default="99" Mode="" Description="Container Variable: USERMAP_UID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>

--- a/templates/paperless.xml
+++ b/templates/paperless.xml
@@ -58,11 +58,6 @@ Additional Template Variables: https://github.com/the-paperless-project/paperles
   <Environment>
     <Variable>
       <Value/>
-      <Name>PAPERLESS_OCR_LANGUAGES</Name>
-      <Mode/>
-    </Variable>
-    <Variable>
-      <Value/>
       <Name>PAPERLESS_OCR_LANGUAGE</Name>
       <Mode/>
     </Variable>
@@ -93,7 +88,6 @@ Additional Template Variables: https://github.com/the-paperless-project/paperles
   <Config Name="Media" Target="/usr/src/paperless/media" Default="" Mode="rw" Description="Container Path: /usr/src/paperless/media . &#13;&#10;Once consumed, files will be stored here." Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Consumption" Target="/consume" Default="" Mode="rw" Description="Container Path: /consume . &#13;&#10;Files placed here will be consumed by paperless." Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Export" Target="/export" Default="" Mode="rw" Description="Container Path: /export . &#13;&#10;Location for files used by the exporter utility.&#13;&#10;See https://paperless.readthedocs.io/en/latest/utilities.html#the-exporter" Type="Path" Display="always" Required="false" Mask="false"/>
-  <Config Name="PAPERLESS_OCR_LANGUAGES" Target="PAPERLESS_OCR_LANGUAGES" Default="eng" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGES . If you want the OCR to recognize other languages in addition to the default English, set this parameter to a space separated list of three-letter language-codes after ISO 639-2/T" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_OCR_LANGUAGE" Target="PAPERLESS_OCR_LANGUAGE" Default="eng" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGE . Override the language that tesseract will attempt to use when parsing documents. Use a 3-letter language code consistent with ISO 639: https://www.loc.gov/standards/iso639-2/php/code_list.php" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_FORGIVING_OCR" Target="PAPERLESS_FORGIVING_OCR" Default="false" Mode="" Description="Container Variable: PAPERLESS_FORGIVING_OCR . &#13;&#10;When true, Paperless will consume documents even if the language detection fails." Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_INLINE_DOC" Target="PAPERLESS_INLINE_DOC" Default="false" Mode="" Description="Container Variable: PAPERLESS_INLINE_DOC.&#13;&#10;When true, PDF files will be viewed in the browser. When false (default), PDF files will be downloaded." Type="Variable" Display="always" Required="false" Mask="false"/>


### PR DESCRIPTION
### Changes

* Add more ENV vars
* Set default for data directory
* Add more documentation
* Link install instructions from unRaid forum

> Thanks to @ljm42 as this is [original his work](https://github.com/ljm42/unRAID-CA-templates/blob/master/templates/paperless.xml)! I just did the review and thought it would be simpler if I just propose the PR. 

### Conducted Tests

* I added my fork of this repo to the docker templates of my unRaid Server and started my productive paperless instance with the changes proposed here. Everything looks fine. 