### PR TITLE
Add additional env variables to paperless template

### DIFF
--- a/templates/paperless.xml
+++ b/templates/paperless.xml
@@ -62,6 +62,11 @@ Additional Template Variables: https://github.com/the-paperless-project/paperles
     </Variable>
     <Variable>
       <Value/>
+      <Name>PAPERLESS_OCR_LANGUAGES</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value/>
       <Name>PAPERLESS_FORGIVING_OCR</Name>
       <Mode/>
     </Variable>
@@ -80,6 +85,11 @@ Additional Template Variables: https://github.com/the-paperless-project/paperles
       <Name>USERMAP_UID</Name>
       <Mode/>
     </Variable>
+    <Variable>
+      <Value/>
+      <Name>USERMAP_GID</Name>
+      <Mode/>
+    </Variable>
   </Environment>
   <Config Name="Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false"/>
   <Config Name="Data" Target="/usr/src/paperless/data" Default="/mnt/user/appdata/paperless/data" Mode="rw" Description="Container Path: /usr/src/paperless/data . &#13;&#10;This contains the paperless database. Should be in appdata." Type="Path" Display="always" Required="true" Mask="false"/>
@@ -87,8 +97,10 @@ Additional Template Variables: https://github.com/the-paperless-project/paperles
   <Config Name="Consumption" Target="/consume" Default="" Mode="rw" Description="Container Path: /consume . &#13;&#10;Files placed here will be consumed by paperless." Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Export" Target="/export" Default="" Mode="rw" Description="Container Path: /export . &#13;&#10;Location for files used by the exporter utility.&#13;&#10;See https://paperless.readthedocs.io/en/latest/utilities.html#the-exporter" Type="Path" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_OCR_LANGUAGE" Target="PAPERLESS_OCR_LANGUAGE" Default="eng" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGE . Override the language that tesseract will attempt to use when parsing documents. Use a 3-letter language code consistent with ISO 639: https://www.loc.gov/standards/iso639-2/php/code_list.php" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PAPERLESS_OCR_LANGUAGES" Target="PAPERLESS_OCR_LANGUAGES" Default="eng" Mode="" Description="Container Variable: PAPERLESS_OCR_LANGUAGES . Additional languages to install for text recognition. Use a space separated list of 3-letter language codes consistent with ISO 639: https://www.loc.gov/standards/iso639-2/php/code_list.php" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_FORGIVING_OCR" Target="PAPERLESS_FORGIVING_OCR" Default="false" Mode="" Description="Container Variable: PAPERLESS_FORGIVING_OCR . &#13;&#10;When true, Paperless will consume documents even if the language detection fails." Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_INLINE_DOC" Target="PAPERLESS_INLINE_DOC" Default="false" Mode="" Description="Container Variable: PAPERLESS_INLINE_DOC.&#13;&#10;When true, PDF files will be viewed in the browser. When false (default), PDF files will be downloaded." Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PAPERLESS_TIME_ZONE" Target="PAPERLESS_TIME_ZONE" Default="UTC" Mode="" Description="Container Variable: PAPERLESS_TIME_ZONE.&#13;&#10;Override the default UTC time zone. For details see: https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-TIME_ZONE" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="PUID" Target="USERMAP_UID" Default="99" Mode="" Description="Container Variable: USERMAP_UID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="PGID" Target="USERMAP_GID" Default="100" Mode="" Description="Container Variable: USERMAP_GID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
## Changes

* Added `GID` to have files owned by the group `user` (https://github.com/the-paperless-project/paperless/pull/599)
* Added `PAPERLESS_OCR_LANGUAGES` to allow downloading tesseract data different from `eng`

> Thanks to @ljm42 for contributing the GID fix to paperless project