### PR TITLE
Rename Mango to fix error

### DIFF
--- a/templates/mango.xml
+++ b/templates/mango.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>hkalexling/mango</Name>
+  <Name>Mango</Name>
   <Repository>hkalexling/mango</Repository>
   <Registry>https://hub.docker.com/r/hkalexling/mango</Registry>
   <Network>bridge</Network>


### PR DESCRIPTION
The current name "hkalexling/mango" causes an error when you try to build the docker image.
This PR renames it to just "Mango" to avoid that error.