### PR TITLE
[Deemix] Updated project URL

### DIFF
--- a/templates/deemix.xml
+++ b/templates/deemix.xml
@@ -5,7 +5,7 @@
   <Registry>https://registry.gitlab.com/bockiii/deemix-docker</Registry>
   <Network>bridge</Network>
   <Support>https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
-  <Project>https://git.rip/RemixDev/deemix</Project>
+  <Project>https://faq.deemix.app</Project>
   <Overview>deemix is a deezer downloader built from the ashes of Deezloader Remix. The base library (or core) can be used as a stand alone CLI app or implemented in an UI using the API.</Overview>
   <Category>MediaApp:Music Status:Beta</Category>
   <WebUI>http://[IP]:[PORT:6595]/</WebUI>


### PR DESCRIPTION
Hi,

the project URL (the old repo) was seized, so I changed it to the website FAQ. Even though not all the links on there work, it gives more information and it's at least better than an FBI warning :D 