### PR TITLE
Add Requires, Changelog and ExtraSearchTerms to paperless-ng

### DIFF
--- a/templates/paperless-ng.xml
+++ b/templates/paperless-ng.xml
@@ -9,6 +9,7 @@
   <Requires>Redis container installed</Requires>
   <Support>https://forums.unraid.net/topic/100843-support-paperless-ng-docker/</Support>
   <Project>https://github.com/jonaswinkler/paperless-ng</Project>
+  <Changes>https://paperless-ng.readthedocs.io/en/latest/changelog.html</Changes>
   <Overview>
   Index and archive all of your scanned paper documents. Paperless-ng is a fork of paperless, adding a new interface and many other changes under the hood.[br][br]
   [b]Requirements:[/b] Paperless-ng requires Redis as external service. You can install it from the CA store. Make sure to adjust the configuration in the template accordingly.

--- a/templates/paperless-ng.xml
+++ b/templates/paperless-ng.xml
@@ -6,6 +6,7 @@
   <Network>bridge</Network>
   <Shell>bash</Shell>
   <Privileged>false</Privileged>
+  <Requires>Redis container installed</Requires>
   <Support>https://forums.unraid.net/topic/100843-support-paperless-ng-docker/</Support>
   <Project>https://github.com/jonaswinkler/paperless-ng</Project>
   <Overview>

--- a/templates/paperless-ng.xml
+++ b/templates/paperless-ng.xml
@@ -10,6 +10,7 @@
   <Support>https://forums.unraid.net/topic/100843-support-paperless-ng-docker/</Support>
   <Project>https://github.com/jonaswinkler/paperless-ng</Project>
   <Changes>https://paperless-ng.readthedocs.io/en/latest/changelog.html</Changes>
+  <ExtraSearchTerms>dms archiving document-management-system</ExtraSearchTerms>
   <Overview>
   Index and archive all of your scanned paper documents. Paperless-ng is a fork of paperless, adding a new interface and many other changes under the hood.[br][br]
   [b]Requirements:[/b] Paperless-ng requires Redis as external service. You can install it from the CA store. Make sure to adjust the configuration in the template accordingly.


### PR DESCRIPTION
This pull request adds

* the `Requires` tag
* the `Changelog` tag
* the `ExtraSearchTerms` tag

See the [Docker Template XML Schema Topic](https://forums.unraid.net/topic/38619-docker-template-xml-schema/) for tag descriptions. Once this is merged, I will inform the maintainer of the [Community-Applications-Moderators](https://github.com/Squidly271/Community-Applications-Moderators/blob/master/Moderation.json) repository to remove the `Requires` tag from `paperless-ng` as it is then maintained in the template.

Let me know if something needs a change. Thank you.