### PR TITLE
Add required hostname to notifiarr container.

### DIFF
--- a/templates/notifiarr.xml
+++ b/templates/notifiarr.xml
@@ -10,6 +10,7 @@
   <Support>https://golift.io/discord/</Support>
   <Project>https://github.com/Notifiarr/notifiarr</Project>
   <Category>MediaApp:Video MediaApp:Music MediaApp:Books</Category>
+  <ExtraParams>--hostname=$(hostname -f)</ExtraParams>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/notifiarr.xml</TemplateURL>
   <Icon>https://docs.notifiarr.com/img/icon.png</Icon>
   <Overview>


### PR DESCRIPTION
The next release of notifiarr client uses the hostname to identify the client. Without this setting the hostname changes with every container upgrade. This keeps the name consistent across upgrades.