### PR TITLE
Update airdcpp.xml

### DIFF
--- a/templates/airdcpp.xml
+++ b/templates/airdcpp.xml
@@ -10,20 +10,19 @@
   <Overview>AirDC++ Web Client is a locally installed application, which is designed for frequent sharing of files or directories within groups of people in a local network or over internet. The daemon application can be installed on different types of systems, such as on file servers and NAS devices.&#xD;
 &#xD;
 Username / password for the default admin account is: admin / password</Overview>
-  <Category>Cloud:</Category>
+  <Category>Cloud:File sharing:Direct Connect</Category>
   <WebUI>http://[IP]:[PORT:5600]</WebUI>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/airdcpp.png</Icon>
   <Description>AirDC++ Web Client is a locally installed application, which is designed for frequent sharing of files or directories within groups of people in a local network or over internet. The daemon application can be installed on different types of systems, such as on file servers and NAS devices.&#xD;
 &#xD;
 Username / password for the default admin account is: admin / password</Description>
+  <ExtraParams>--user 99:100</ExtraParams>
   <Config Name="WebUI HTTP_PORT" Target="5600" Default="" Mode="tcp" Description="Container Port: 5600" Type="Port" Display="always" Required="true" Mask="false"/>
   <Config Name="WebUI HTTPS_PORT" Target="5601" Default="" Mode="tcp" Description="Container Port: 5601" Type="Port" Display="always" Required="false" Mask="false"/>
   <Config Name="TCP_PORT" Target="21248" Default="" Mode="tcp" Description="Published TCP port for incoming connections. Defaults to 21248." Type="Port" Display="always" Required="true" Mask="false"/>
   <Config Name="UDP_PORT" Target="21248" Default="" Mode="udp" Description="Published UDP port for incoming connections. Defaults to 21248." Type="Port" Display="always" Required="true" Mask="false"/>
   <Config Name="TLS_PORT" Target="21249" Default="" Mode="tcp" Description="Published TLS port for incoming connections. Defaults to 21249." Type="Port" Display="always" Required="true" Mask="false"/>
-  <Config Name="Data Storage" Target="/airdcpp" Default="" Mode="rw" Description="Container Path: /airdcpp" Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Application data" Target="/.airdcpp" Default="" Mode="rw" Description="Container Path: /.airdcpp" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Downloads" Target="/Downloads" Default="" Mode="rw" Description="Container Path: /Downloads" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Share" Target="/Share" Default="" Mode="rw" Description="Container Path: /Share" Type="Path" Display="always" Required="true" Mask="false"/>
-  <Config Name="UID" Target="UID" Default="99" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="false" Mask="false"/>
-  <Config Name="GID" Target="GID" Default="100" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
- Fixed the application data folder, correct path is `/.airdcpp`.
- Removed UID/GID which is no longer supported for IDs lover than 101.
  Extra parameter `--user 99:100` must be used instead.
- Added a few categories

closes #279 