### PR TITLE
Username change of Kdenlive VNC

### DIFF
--- a/templates/kdenlive.xml
+++ b/templates/kdenlive.xml
@@ -6,7 +6,7 @@
   <Category>MediaApp:Video MediaApp:Music Productivity: Tools:</Category>
   <Network>bridge</Network>
   <Support>hhttps://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
-  <Project>https://github.com/TessyPowder/kdenlive-vnc-docker</Project>
+  <Project>https://github.com/JonathanTreffler/kdenlive-vnc-docker</Project>
   <Privileged>false</Privileged>
   <Overview>An instance of kdenlive accessible through vnc and noVnc (=Web Interface)</Overview>
   <WebUI>http://[IP]:[PORT:5800]</WebUI>


### PR DESCRIPTION
I changed my username ages ago from TessyPowder to JonathanTreffler.
Because nobody else registered a GitHub account with the username TessyPowder so far the current link redirects to the new link.
Also the username under the repository name when viewing the application in the Cummunity Applications Plugin is still tessypowder, is that derived from the dockerhub username (still tessypowder) or Github or can you change that too ?