### PR TITLE
Update Deemix template for new single user mode

### DIFF
--- a/templates/deemix.xml
+++ b/templates/deemix.xml
@@ -15,6 +15,5 @@
   <Config Name="PGID" Target="PGID" Default="" Mode="" Description="Container Variable: PGID" Type="Variable" Display="advanced-hide" Required="false" Mask="false">100</Config>
   <Config Name="Downloads" Target="/downloads" Default="" Mode="rw" Description="Container Path: /downloads" Type="Path" Display="always" Required="false" Mask="false"/>
   <Config Name="Appdata" Target="/config" Default="" Mode="rw" Description="Container Path: /config" Type="Path" Display="always" Required="false" Mask="false"/>
-  <Config Name="ARL Token" Target="ARL" Default="" Mode="" Description="Container Variable: ARL" Type="Variable" Display="always" Required="false" Mask="false"/>
-  <Config Name="Old UI" Target="DEEZUI" Default="false|true" Mode="" Description="Container Variable: DEEZUI" Type="Variable" Display="always" Required="false" Mask="false">false</Config>
+  <Config Name="Single User Mode" Target="DEEMIX_SINGLE_USER" Default="false" Mode="" Description="Container Variable: Single User" Type="Variable" Display="always" Required="false" Mask="false"/>
 </Container>

--- a/templates/deemix.xml
+++ b/templates/deemix.xml
@@ -15,5 +15,5 @@
   <Config Name="PGID" Target="PGID" Default="" Mode="" Description="Container Variable: PGID" Type="Variable" Display="advanced-hide" Required="false" Mask="false">100</Config>
   <Config Name="Downloads" Target="/downloads" Default="" Mode="rw" Description="Container Path: /downloads" Type="Path" Display="always" Required="false" Mask="false"/>
   <Config Name="Appdata" Target="/config" Default="" Mode="rw" Description="Container Path: /config" Type="Path" Display="always" Required="false" Mask="false"/>
-  <Config Name="Single User Mode" Target="DEEMIX_SINGLE_USER" Default="false" Mode="" Description="Container Variable: Single User" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Single User Mode" Target="DEEMIX_SINGLE_USER" Default="false|true" Mode="" Description="Container Variable: Single User" Type="Variable" Display="always" Required="false" Mask="false">false</Config>
 </Container>


### PR DESCRIPTION
Hi,

"OldUI" doesnt to anything anymore.
"ARL" was the previous way to provide an ARL. The ARL is not picked up anymore but I implemented a legacy behavior so that if "anything" is set in the ARL, the image activates the single user mode.

"Single user mode" is the replacement for the old ARL functionality. It will signify to the application to store its login data locally, so only one user has to log in to the application and every subsequent session will use that login data.