### PR TITLE
Update scrutiny.xml, config and influxdb

### DIFF
--- a/templates/scrutiny.xml
+++ b/templates/scrutiny.xml
@@ -16,5 +16,6 @@
   <Config Name="Host Path 1" Target="/run/udev" Default="/run/udev" Mode="ro" Description="Container Path: /run/udev" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Host Path 2" Target="/dev/disk" Default="/dev/disk" Mode="ro" Description="Container Path: /dev/disk" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: " Type="Port" Display="always" Required="false" Mask="false"/>
-  <Config Name="Appdata" Target="/scrutiny/config" Default="" Mode="rw" Description="Container Path: /scrutiny/config" Type="Path" Display="always" Required="false" Mask="false"/>
+  <Config Name="Config" Target="/opt/scrutiny/config" Default="" Mode="rw" Description="Container Path: /opt/scrutiny/config" Type="Path" Display="always" Required="false" Mask="false"/>
+  <Config Name="Database" Target="/opt/scrutiny/influxdb" Default="" Mode="rw" Description="Container Path: /opt/scrutiny/influxdb" Type="Path" Display="always" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
it seems like scrutiny is using influxdb now
https://github.com/AnalogJ/scrutiny#docker
I edit my local config like this, so it keeps the database after update
