### PR TITLE
Prometheus: fix permission error on data folder

### DIFF
--- a/templates/prometheus.xml
+++ b/templates/prometheus.xml
@@ -13,6 +13,6 @@
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/prometheus.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/prometheus.png</Icon>
   <Config Name="Port" Target="9090" Default="9090" Mode="tcp" Description="Container Port: 9090" Type="Port" Display="always" Required="false" Mask="false"/>
-  <Config Name="Appdata" Target="/prometheus" Default="/mnt/user/appdata/prometheus/data" Mode="rw" Description="Appdata directory" Type="Path" Display="advanced" Required="true" Mask="false"/>
+  <Config Name="Appdata" Target="/prometheus/data" Default="/mnt/user/appdata/prometheus/data" Mode="rw" Description="Appdata directory" Type="Path" Display="advanced" Required="true" Mask="false"/>
   <Config Name="Config" Target="/etc/prometheus/" Default="/mnt/user/appdata/prometheus/etc" Mode="rw" Description="Config directory" Type="Path" Display="advanced" Required="true" Mask="false"/>
 </Container>


### PR DESCRIPTION
I kept getting a fatal error when trying to start Prometheus. After doing some investigating, I noticed that Docker added the data folder to the root of `/prometheus` instead of `/prometheus/data`. 

After updating the path, it works like a charm.

This was the error:

```
caller=query_logger.go:86 level=error component=activeQueryTracker msg="Error opening query log file" file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"


panic: Unable to create mmap-ed active query log

goroutine 1 [running]:
github.com/prometheus/prometheus/promql.NewActiveQueryTracker({0x7ffc79a57eac, 0xb}, 0x14, {0x3547580, 0xc00080f540})
/app/promql/query_logger.go:116 +0x3d7
main.main()
/app/cmd/prometheus/main.go:567 +0x5c93
```