### PR TITLE
Add start subcommand to kopia.xml

### DIFF
--- a/templates/kopia.xml
+++ b/templates/kopia.xml
@@ -15,7 +15,7 @@ To run this container, you must create a htpasswd file (either via command line 
   <WebUI>http://[IP]:[PORT:51515]</WebUI>
   <TemplateURL>https://github.com/selfhosters/unRAID-CA-templates/blob/master/templates/kopia.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/kopia/kopia/master/icons/kopia.svg</Icon>
-  <PostArgs>server --insecure --htpasswd-file /app/config/htpasswd --address 0.0.0.0:51515 --server-username=YOUR-USERNAME</PostArgs>
+  <PostArgs>server start --insecure --htpasswd-file /app/config/htpasswd --address 0.0.0.0:51515 --server-username=YOUR-USERNAME</PostArgs>
   <Config Name="Repository password" Target="KOPIA_PASSWORD" Default="" Mode="" Description="Container Variable: KOPIA_PASSWORD" Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="Port" Target="51515" Default="51515" Mode="tcp" Description="Container Port: 51515" Type="Port" Display="always" Required="true" Mask="false">51515</Config>
   <Config Name="Config path" Target="/app/config" Default="/mnt/user/appdata/kopia/config" Mode="rw" Description="Container Path: /app/config" Type="Path" Display="always" Required="true" Mask="false"/>


### PR DESCRIPTION
With Kopia's v0.13.0 release yesterday, they introduced breaking changes to the CLI by removing default subcommands. Found in this PR https://github.com/kopia/kopia/pull/2861

With this new release, you have to manually specify `server start` in order for it to actually start the server. Otherwise you get the error `error: unknown long flag '--insecure', try --help`


Please let me know if there's anything else I need to do to get this PR ready to merge :) Thanks!