### PR TITLE
fix: komga port changed from 8080 to 25600

### DIFF
--- a/templates/komga.xml
+++ b/templates/komga.xml
@@ -10,10 +10,10 @@
   <Overview>A Media server for comics/mangas/BDs with API and OPDS support.&#xD;
 Check logs for auto-generated username/password.</Overview>
   <Category>Network:Web MediaServer:Books Tools:Utilities</Category>
-  <WebUI>http://[IP]:[PORT:8080]</WebUI>
+  <WebUI>http://[IP]:[PORT:25600]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/komga.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/komga.png</Icon>
-  <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false"/>
+  <Config Name="WebUI" Target="25600" Default="25600" Mode="tcp" Description="Container Port: 25600" Type="Port" Display="always" Required="true" Mask="false"/>
   <Config Name="Exclusions" Target="KOMGA_LIBRARIES_SCAN_DIRECTORY_EXCLUSIONS" Default="#recycle,@eaDir" Description="Container Variable: KOMGA_LIBRARIES_SCAN_DIRECTORY_EXCLUSIONS" Type="Variable" Display="advanced" Required="true" Mask="false"/>
   <Config Name="Config" Target="/config" Default="/mnt/user/appdata/komga/" Mode="rw" Description="Container Path: /config" Type="Path" Display="advanced" Required="true" Mask="false"/>
   <Config Name="Books" Target="/books" Default="/mnt/user/Media/books" Mode="rw" Description="Container Path: /books" Type="Path" Display="always" Required="true" Mask="false"/>


### PR DESCRIPTION
Komga has been updated to v1.0, which changes the port from 8080 to 25600. 
This pull request updates the project to use the new port.

> With the release of the version 1.0 of Komga, the default port went from 8080 to 25600 so the template need to be fixed for Komga to work after update.
> More infos here : https://komga.org/installation/upgrade.html

[[Support] selfhosters.net's Template Repository - Docker Containers - Unraid](https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/?do=findComment&comment=1277355)