### PR TITLE
Update icon path, add Bitfocus in name and lowercase Companion.xml

### DIFF
--- a/templates/companion.xml
+++ b/templates/companion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>Companion</Name>
+  <Name>Bitfocus-Companion</Name>
   <Repository>ghcr.io/bitfocus/companion/companion:latest</Repository>
   <Registry>https://github.com/bitfocus/companion/pkgs/container/companion%2Fcompanion</Registry>
   <Network>bridge</Network>
@@ -8,14 +8,14 @@
   <Privileged>false</Privileged>
   <Support>https://bitfocus.io/companion/support</Support>
   <Project>https://bitfocus.io/companion/</Project>
-  <Overview>Official image of Bitfocus companion.&#xD;
+  <Overview>Official image of Bitfocus Companion.&#xD;
 &#xD;
 Bitfocus Companion enables the reasonably priced Elgato Streamdeck to be a professional shotbox surface for an increasing amount of different presentation switchers, video playback software and broadcast equipment.&#xD;
 &#xD;
 You don't need an actual stream deck to use it. Companion both comes with a builtin stream deck emulator, a webpage for touch screens and the ability to trigger buttons via OSC, TCP, UDP, HTTP, WebSocket and ArtNet. It does the same job, just without the buttons.</Overview>
   <Category>Productivity:</Category>
   <WebUI>http://[IP]:[PORT:8000]</WebUI>
-  <Icon>https://raw.githubusercontent.com/bitfocus/companion/master/assets/icon.png</Icon>
+  <Icon>https://raw.githubusercontent.com/bitfocus/companion/master/launcher/assets/icon.png</Icon>
   <Description>Official image of Bitfocus companion.&#xD;
 &#xD;
 Bitfocus Companion enables the reasonably priced Elgato Streamdeck to be a professional shotbox surface for an increasing amount of different presentation switchers, video playback software and broadcast equipment.&#xD;


### PR DESCRIPTION
The icon URL was returning a 404. Updated the URL to work again.
When this first came out on Unraid I put a post up about it on the official Companion Facebook user group and one of the lead developers said that the package should be named "Bitfocus Companion". So I've updated that as well. I also changed it from Companion.xml to companion.xml so that it sorts alphabetically in the templates folder.