### PR TITLE
Create template for prom-alertmanager docker container

### DIFF
--- a/templates/prom-alertmanager.xml
+++ b/templates/prom-alertmanager.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>prom-alertmanager</Name>
+  <Repository>prom/alertmanager:latest</Repository>
+  <Registry>https://hub.docker.com/r/prom/alertmanager</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
+  <Project>https://github.com/prometheus/alertmanager</Project>
+  <Overview>The Alertmanager handles alerts sent by client applications such as the Prometheus
+    server. &#xD;
+    It takes care of deduplicating, grouping, and routing them to the correct receiver integrations
+    such as email, PagerDuty, OpsGenie, or many other mechanisms thanks to the webhook receiver.
+    &#xD;
+    It also takes care of silencing and inhibition of alerts.&#xD;
+    &#xD;
+    alertmanager/alertmanager.yml&#xD;
+    This configuration contains information about which channels to send to. For simplicity, we use
+    e-mail. Refer to the Alertmanager docs to learn about other channels.&#xD;
+    &#xD;
+    To configure prometheus to use these alerts, add the below to prometheus/prometheus.yml:&#xD;
+    alerting:&#xD;
+    alertmanagers:&#xD;
+    - scheme: http&#xD;
+    static_configs:&#xD;
+    - targets: &amp;lt; 'alertmanager:9093' &amp;gt;</Overview>
+  <Category>Productivity:</Category>
+  <WebUI>http://[IP]:[PORT:9093]</WebUI>
+  <TemplateURL>
+    https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/prom-alertmanager.xml</TemplateURL>
+  <Icon>
+    https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/prometheus.png</Icon>
+  <Requires />
+  <Config Name="Port" Target="9093" Default="9093" Mode="tcp" Description="" Type="Port"
+    Display="always" Required="false" Mask="false">
+  </Config>
+  <Config Name="Storage" Target="/alertmanager" Default="/mnt/user/appdata/alertmanager/storage" Mode="rw"
+    Description="" Type="Path" Display="always" Required="false" Mask="false">
+    /mnt/user/appdata/alertmanager/storage
+  </Config>
+  <Config Name="ConfigFile" Target="/etc/alertmanager/alertmanager.yaml"
+    Default="/mnt/user/appdata/alertmanager/alertmanager.yaml" Mode="rw"
+    Description="Config directory" Type="Path" Display="advanced" Required="false" Mask="false">
+    /mnt/user/appdata/alertmanager/alertmanager.yaml</Config>
+  <Config Name="Appdata" Target="" Default="/mnt/user/appdata/alertmanager" Mode="rw"
+    Description="Appdata directory" Type="Path" Display="advanced" Required="false" Mask="false">
+    /mnt/user/appdata/alertmanager
+  </Config>
+</Container>


### PR DESCRIPTION
Application install for this was missing so went ahead and created it based off the official dockerfile and image.
Tested locally but first time creating a template so let me know if you see any issues.
This is the guide I followed.
https://selfhosters.net/docker/templating/templating/