### PR TITLE
Dozzle template: applied changes to reflect new authentication method

### DIFF
--- a/templates/dozzle.xml
+++ b/templates/dozzle.xml
@@ -6,17 +6,17 @@
   <Network>bridge</Network>
   <Support>https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
   <Project>https://github.com/amir20/dozzle</Project>
-  <Overview>Dozzle is a real-time log viewer for docker containers. </Overview>
+  <Overview>Dozzle is a real-time log viewer for docker containers. As of v6.x, a new Authentication mechanism is in place that requires you to create a /data/users.yml file as described in https://github.com/amir20/dozzle/issues/2630</Overview>
   <Category>Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:8080]/</WebUI>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/dozzle.png</Icon>
-  <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8888" Type="Port" Display="always" Required="false" Mask="false"/>
+  <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false"/>
   <Config Name="Docker Logs" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="ro" Description="Container Path: /var/run/docker.sock" Type="Path" Display="always" Required="true" Mask="false"/>
-  <Config Name="Username" Target="DOZZLE_USERNAME" Default="" Mode="" Description="Container Variable: DOZZLE_USERNAME" Type="Variable" Display="always" Required="false" Mask="false"/>
-  <Config Name="Password" Target="DOZZLE_PASSWORD" Default="" Mode="" Description="Container Variable: DOZZLE_PASSWORD" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Base URL" Target="DOZZLE_BASE" Default="/" Mode="" Description="Container Variable: DOZZLE_BASE" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Log Level" Target="DOZZLE_LEVEL" Default="info" Mode="" Description="Container Variable: DOZZLE_LEVEL" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Log Tailsize" Target="DOZZLE_TAILSIZE" Default="300" Mode="" Description="Container Variable: DOZZLE_TAILSIZE" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="/data" Target="/data" Default="/mnt/user/appdata/dozzle/" Mode="rw" Description="/data directory for /data/users.yml" Type="Path" Display="always" Required="false" Mask="false"/>
+  <Config Name="Authentication" Target="DOZZLE_AUTH_PROVIDER" Default="simple" Mode="" Description="Container Variable: DOZZLE_AUTH_PROVIDER" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Secret Key" Target="DOZZLE_KEY" Default="9Q9SJ69MZhZ0WrjbF" Mode="" Description="Container Variable: DOZZLE_KEY . Dozzle uses this to make session tokens. If you expose dozzle on the internet, you need to change this, since the default secret is well known" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Disable Analytics" Target="DOZZLE_NO_ANALYTICS" Default="true" Mode="" Description="Container Variable: DOZZLE_NO_ANALYTICS . Dozzle collects anonymous user configurations using Google Analytics." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
An updated version of the `dozzle` template to reflect the changes noted in the [Unraid Forum](https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/?do=findComment&comment=1347340) and the information in Dozzle notice of deprecation (https://github.com/amir20/dozzle/issues/2630)