### PR TITLE
Update Prometheus's data directory mapping + fixed permissions error.

### DIFF
--- a/templates/prometheus.xml
+++ b/templates/prometheus.xml
@@ -12,7 +12,8 @@
   <Category>Productivity:</Category>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/prometheus.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/prometheus.png</Icon>
+  <ExtraParams>--user 99:100</ExtraParams>
   <Config Name="Port" Target="9090" Default="9090" Mode="tcp" Description="Container Port: 9090" Type="Port" Display="always" Required="false" Mask="false"/>
-  <Config Name="Appdata" Target="/prometheus/data" Default="/mnt/user/appdata/prometheus/data" Mode="rw" Description="Appdata directory" Type="Path" Display="advanced" Required="true" Mask="false"/>
+  <Config Name="Appdata" Target="/prometheus" Default="/mnt/user/appdata/prometheus/data" Mode="rw" Description="Appdata directory" Type="Path" Display="advanced" Required="true" Mask="false"/>
   <Config Name="Config" Target="/etc/prometheus/" Default="/mnt/user/appdata/prometheus/etc" Mode="rw" Description="Config directory" Type="Path" Display="advanced" Required="true" Mask="false"/>
 </Container>


### PR DESCRIPTION
A [change](https://github.com/prometheus/prometheus/commit/ceb844aa1ad7511ee22ecfee65fe34ba59a987df) to the Dockerfile for Prometheus has overridden the default data storage directory from `/prometheus/data` to `/prometheus`. This means any new containers created using this template will technically continue to work, but due to the data being stored in a transient docker volume, and not on the intended UnRAID appdata share, the data will not survive the container being recreated.

I noticed this myself when trying to find why Grafana only showed a weeks worth of data, despite the Prometheus being configured by default to retain 15 days. (and I clean up docker volumes every so often).

N.B. This will overwrite the data currently in your docker volume, with your presumedly empty appdata folder. To get around this, I manually copied `/prometheus/*` to `/prometheus/data/` before applying this update.

After making this change on my own server, the Prometheus container refused to start, due to permission denied when reading the new data. I found this was because while the container's process is configured to run as `nobody`, the UID doesn't match the UID of UnRAID's `nobody`, therefore added the `--user 99:100` to override the container's UID got things working smoothly. On UnRAID, UID 99 maps to `nobody`, and GID 100 maps to `users`, which should be the default permissions, but you might have to run `chown -r nobody:users /mnt/user/appdata/prometheus/` if you copied the data from volume to share, as mentioned above.