### PR TITLE
Update `preview-maid` template with new vars

### DIFF
--- a/templates/preview-maid.xml
+++ b/templates/preview-maid.xml
@@ -15,6 +15,6 @@
   <Config Name="PLEX_URL" Target="PLEX_URL" Default="" Mode="" Description="The URL to your Plex instance" Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="PLEX_TOKEN" Target="PLEX_TOKEN" Default="" Mode="" Description="Your plex token" Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="RUN_ONCE" Target="RUN_ONCE" Default="False|True" Mode="" Description="Set to true if you wish for only on run after which the container will terminate." Type="Variable" Display="always" Required="true" Mask="false"/>
-  <Config Name="SKIP_LIBRARY_TYPES" Target="SKIP_LIBRARY_TYPES" Default="" Mode="" Description="A comma separated list of library types to skip. Options are tv,movie,photo" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SKIP_LIBRARY_TYPES" Target="SKIP_LIBRARY_TYPES" Default="" Mode="" Description="A comma separated list of library types to skip. Options are tv,movie,photo" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="SKIP_LIBRARY_NAMES" Target="SKIP_LIBRARY_NAMES" Default="" Mode="" Description="A comma separated list of library names to skip" Type="Variable" Display="always" Required="true" Mask="false"/>
 </Container>

--- a/templates/preview-maid.xml
+++ b/templates/preview-maid.xml
@@ -8,11 +8,13 @@
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
   <Project>https://github.com/fletchto99/preview-maid</Project>
-  <Overview>Preview maid is a tool to help you find missing thumbnail previews in your plex library. By default it will run upon start and then on a schedule daily at 00:00.</Overview>
+  <Overview>Preview maid is a tool to help you find missing thumbnail previews in your plex library. By default it will run on a schedule at 00:00. Optionally you can have it run once and output before exiting.</Overview>
   <Category>Tools:Utilities Status:Stable</Category>
   <TemplateURL>https://github.com/selfhosters/unRAID-CA-templates/blob/master/templates/preview-maid.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/preview-maid.png</Icon>
   <Config Name="PLEX_URL" Target="PLEX_URL" Default="" Mode="" Description="The URL to your Plex instance" Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="PLEX_TOKEN" Target="PLEX_TOKEN" Default="" Mode="" Description="Your plex token" Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="RUN_ONCE" Target="RUN_ONCE" Default="False|True" Mode="" Description="Set to true if you wish for only on run after which the container will terminate." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SKIP_LIBRARY_TYPES" Target="SKIP_LIBRARY_TYPES" Default="" Mode="" Description="A comma separated list of library types to skip. Options are tv,movie,photo" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SKIP_LIBRARY_NAMES" Target="SKIP_LIBRARY_NAMES" Default="" Mode="" Description="A comma separated list of library names to skip" Type="Variable" Display="always" Required="true" Mask="false"/>
 </Container>

--- a/templates/preview-maid.xml
+++ b/templates/preview-maid.xml
@@ -16,5 +16,5 @@
   <Config Name="PLEX_TOKEN" Target="PLEX_TOKEN" Default="" Mode="" Description="Your plex token" Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="RUN_ONCE" Target="RUN_ONCE" Default="False|True" Mode="" Description="Set to true if you wish for only on run after which the container will terminate." Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="SKIP_LIBRARY_TYPES" Target="SKIP_LIBRARY_TYPES" Default="" Mode="" Description="A comma separated list of library types to skip. Options are tv,movie,photo" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
-  <Config Name="SKIP_LIBRARY_NAMES" Target="SKIP_LIBRARY_NAMES" Default="" Mode="" Description="A comma separated list of library names to skip" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="SKIP_LIBRARY_NAMES" Target="SKIP_LIBRARY_NAMES" Default="" Mode="" Description="A comma separated list of library names to skip" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
This PR updates the template to add a few ENV vars which allow skipping certain libraries by name or type 