### PR TITLE
Fix Jenkins template

### DIFF
--- a/templates/jenkins.xml
+++ b/templates/jenkins.xml
@@ -10,6 +10,7 @@
   <Overview>The leading open source automation server, Jenkins provides hundreds of plugins to support building, deploying and automating any project.</Overview>
   <Category>Productivity: Tools:</Category>
   <WebUI>http://[IP]:[PORT:8080]/</WebUI>
+  <ExtraParams>-u 99:100</ExtraParams>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/jenkins.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/jenkins.png</Icon>
   <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false"/>


### PR DESCRIPTION
Container will not start after install. 

As per Jenkins doc:

> NOTE: Avoid using a bind mount from a folder on the host machine into /var/jenkins_home, as this might result in file permission issues (the user used inside the container might not have rights to the folder on the host machine). If you really need to bind mount jenkins_home, ensure that the directory on the host is accessible by the jenkins user inside the container (jenkins user - uid 1000) or use -u some_other_user parameter with docker run.


This fixes it.