### PR TITLE
Remove execution of command in extra parameters

### DIFF
--- a/templates/notifiarr.xml
+++ b/templates/notifiarr.xml
@@ -11,7 +11,7 @@
   <Project>https://github.com/Notifiarr/notifiarr</Project>
   <Category>MediaApp:Video MediaApp:Music MediaApp:Books</Category>
   <WebUI>http://[IP]:[PORT:5454]/</WebUI>
-  <ExtraParams></ExtraParams>
+  <ExtraParams>--hostname notifiarr</ExtraParams>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/notifiarr.xml</TemplateURL>
   <Icon>https://notifiarr.com/images/logo/notifiarr.png</Icon>
   <Overview>

--- a/templates/notifiarr.xml
+++ b/templates/notifiarr.xml
@@ -11,7 +11,7 @@
   <Project>https://github.com/Notifiarr/notifiarr</Project>
   <Category>MediaApp:Video MediaApp:Music MediaApp:Books</Category>
   <WebUI>http://[IP]:[PORT:5454]/</WebUI>
-  <ExtraParams>--hostname=$(hostname -f)</ExtraParams>
+  <ExtraParams></ExtraParams>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/notifiarr.xml</TemplateURL>
   <Icon>https://notifiarr.com/images/logo/notifiarr.png</Icon>
   <Overview>


### PR DESCRIPTION
Security issue allowing any extra commands to execute.  Maybe innocuous, but can't be allowed.  Further beefing up of the security system caught this