### PR TITLE
Rename TriliumNext Notes, update repo links

### DIFF
--- a/templates/triliumnext.xml
+++ b/templates/triliumnext.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>triliumnext</Name>
-  <Repository>triliumnext/notes:latest</Repository>
-  <Registry>https://hub.docker.com/r/triliumnext/notes</Registry>
+  <Name>trilium</Name>
+  <Repository>ghcr.io/triliumnext/trilium:latest</Repository>
+  <Registry>ghcr.io/triliumnext/trilium</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
-  <Project>https://github.com/TriliumNext/Notes</Project>
-  <Overview>TriliumNext Notes is an open-source, cross-platform hierarchical note taking application with focus on building large personal knowledge bases.</Overview>
+  <Project>https://github.com/TriliumNext/Trilium</Project>
+  <Overview>Trilium Notes is an open-source, cross-platform hierarchical note-taking application with focus on building large personal knowledge bases.</Overview>
   <Category>Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:8080]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/triliumnext.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/triliumnext.png</Icon>
-  <Description>TriliumNext Notes is a hierarchical note taking application with focus on building large personal knowledge bases.</Description>
+  <Description>Trilium Notes is a hierarchical note-taking application with focus on building large personal knowledge bases.</Description>
+  <Changes>
+    ### 2025-08-21
+
+    Rename app from "TriliumNext Notes" to "Trilium Notes" following the upstream project rename.
+  </Changes>
   <Config Name="WebUI" Target="8080" Default="9999" Mode="tcp" Description="WebUI - Default 9999" Type="Port" Display="always-hide" Required="true" Mask="false">9999</Config>
   <Config Name="Appdata" Target="/home/node/trilium-data" Default="/mnt/user/appdata/trilium" Mode="rw" Description="Container Path: /home/node/trilium-data" Type="Path" Display="advanced-hide" Required="true" Mask="false"/>
   <Config Name="Backups" Target="/home/node/trilium-data/backup" Default="/mnt/user/appdata/trilium/backup" Mode="rw" Description="Container Path: /home/node/trilium-data/backup" Type="Path" Display="advanced-hide" Required="true" Mask="false"/>


### PR DESCRIPTION
Rename TriliumNext Notes to Trilium Notes, update repo and GitHub links, following upstream package rename (https://github.com/orgs/TriliumNext/discussions/5867)

File name kept the same to hopefully avoid forcing existing users to manually migrate to a separate template/app (https://github.com/orgs/TriliumNext/discussions/5867#discussioncomment-13412960)