### PR TITLE
Update Twitch Drops Miner with proper paths and support url

### DIFF
--- a/templates/twitch-drops-miner.xml
+++ b/templates/twitch-drops-miner.xml
@@ -5,14 +5,14 @@
   <Registry>https://hub.docker.com/r/dungfu/twitch-drops-miner/</Registry>
   <Network>bridge</Network>
   <Privileged>false</Privileged>
-  <Support>https://github.com/DevilXD/TwitchDropsMiner/issues</Support>
+  <Support>https://github.com/fireph/docker-twitch-drops-miner/issues</Support>
   <Project>https://github.com/DevilXD/TwitchDropsMiner</Project>
   <Overview>AFK mine timed Twitch drops, with automatic drop claiming and channel switching.</Overview>
   <Category>GameServers: Tools:</Category>
   <WebUI>http://[IP]:[PORT:5800]</WebUI>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/twitch-drops-miner.png</Icon>
   <Config Name="Config Path" Target="/TwitchDropsMiner/config" Default="/mnt/user/appdata/twitch-drops-miner/config" Mode="rw" Description="Path to configuration data." Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/twitch-drops-miner/config</Config>
-  <Config Name="Cache Path" Target="/cache" Default="/mnt/user/appdata/twitch-drops-miner/cache" Mode="rw" Description="Path to cache data." Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/twitch-drops-miner/cache</Config>
+  <Config Name="Cache Path" Target="/TwitchDropsMiner/cache" Default="/mnt/user/appdata/twitch-drops-miner/cache" Mode="rw" Description="Path to cache data." Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/twitch-drops-miner/cache</Config>
   <Config Name="Web UI Port" Target="5800" Default="5800" Mode="tcp" Description="Port used to access the application's GUI via the web interface." Type="Port" Display="always" Required="true" Mask="false">5800</Config>
   <Config Name="Display Width" Target="DISPLAY_WIDTH" Default="1920" Mode="" Description="Width (in pixels) of the application's window." Type="Variable" Display="advanced" Required="false" Mask="false">1920</Config>
   <Config Name="Display Height" Target="DISPLAY_HEIGHT" Default="1080" Mode="" Description="Height (in pixels) of the application's window." Type="Variable" Display="advanced" Required="false" Mask="false">1080</Config>


### PR DESCRIPTION
DevilXD does not support and will not help with issues when running in docker, so I updated the support link to the docker github repo. The /cache path was also incorrect and has been fixed.