### PR TITLE
Remove docker mod var from ytdl-sub image

### DIFF
--- a/templates/ytdl-sub.xml
+++ b/templates/ytdl-sub.xml
@@ -21,5 +21,4 @@
   <Config Name="PUID" Target="PUID" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">99</Config>
   <Config Name="PGID" Target="PGID" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">100</Config>
   <Config Name="UMASK" Target="UMASK" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">002</Config>
-  <Config Name="Docker Mods" Target="DOCKER_MODS" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">linuxserver/mods:universal-cron</Config>
 </Container>


### PR DESCRIPTION
Closes https://github.com/jmbannon/ytdl-sub/issues/1369

The ytdl-sub (headless) image includes docker mods in its Dockerfile. This should be removed in favor of that.