### PR TITLE
Fix library-manager: correct Docker image URL and volume paths

### DIFF
--- a/templates/library-manager.xml
+++ b/templates/library-manager.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>library-manager</Name>
-  <Repository>deucebucket/library-manager:latest</Repository>
-  <Registry>https://hub.docker.com/r/deucebucket/library-manager</Registry>
+  <Repository>ghcr.io/deucebucket/library-manager:latest</Repository>
+  <Registry>https://github.com/deucebucket/library-manager/pkgs/container/library-manager</Registry>
   <Network>bridge</Network>
   <Shell>bash</Shell>
   <Privileged>false</Privileged>
@@ -27,8 +27,8 @@
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/library-manager.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/img/library-manager.png</Icon>
   <Config Name="Web UI Port" Target="5757" Default="5757" Mode="tcp" Description="Web interface port" Type="Port" Display="always" Required="true" Mask="false"/>
-  <Config Name="Audiobook Library" Target="/library" Default="" Mode="rw" Description="Path to your audiobook library" Type="Path" Display="always" Required="true" Mask="false"/>
-  <Config Name="Config" Target="/config" Default="/mnt/user/appdata/library-manager" Mode="rw" Description="Configuration and database storage" Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Audiobook Library" Target="/audiobooks" Default="/mnt/user/media/audiobooks" Mode="rw" Description="Path to your audiobook library (use /audiobooks in settings)" Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Data Directory" Target="/data" Default="/mnt/user/appdata/library-manager" Mode="rw" Description="Configuration and database storage" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="User ID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Group ID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
## Summary

The library-manager template currently points to Docker Hub (`deucebucket/library-manager`) but the image is actually hosted on GitHub Container Registry (`ghcr.io/deucebucket/library-manager`). This causes a "pull access denied" error for all users trying to install the container.

## Changes

1. **Repository URL**: `deucebucket/library-manager:latest` → `ghcr.io/deucebucket/library-manager:latest`
2. **Registry URL**: Updated to point to GitHub Container Registry
3. **Volume mounts**: Fixed to match the actual Dockerfile paths:
   - `/library` → `/audiobooks`
   - `/config` → `/data`
4. Added sensible default path for audiobook library

## Testing

Verified the correct image exists and pulls successfully:
```
podman pull ghcr.io/deucebucket/library-manager:latest
```

## Related

- GitHub Issue: https://github.com/deucebucket/library-manager/issues/10 (user report of this issue)

Sorry for the confusion - this was my mistake when I originally submitted the template. I updated it in my repo but forgot that Selfhosters had already grabbed the old version.