### PR TITLE
Add dovi-convert template

### DIFF
--- a/templates/dovi-convert.xml
+++ b/templates/dovi-convert.xml
@@ -27,5 +27,4 @@ Based on the dovi_convert script by cryptochrome.</Overview>
   <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Port for the web interface" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
   <Config Name="Media Path" Target="/media" Default="" Mode="rw" Description="Path to your media library containing Dolby Vision files" Type="Path" Display="always-hide" Required="true" Mask="false"/>
   <Config Name="Config Path" Target="/config" Default="/mnt/user/appdata/dovi-convert" Mode="rw" Description="Path for persistent configuration" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/dovi-convert</Config>
-  <Config Name="TZ" Target="TZ" Default="America/New_York" Mode="" Description="Timezone" Type="Variable" Display="always" Required="false" Mask="false">America/New_York</Config>
 </Container>


### PR DESCRIPTION
## New Template: dovi-convert

**Docker Hub:** https://hub.docker.com/r/smidley/dovi-convert
**GitHub:** https://github.com/smidley/dovi-convert-docker

### Description

DoVi Convert provides a web interface for converting Dolby Vision Profile 7 MKV files (UHD Blu-ray rips) to Profile 8.1 for better compatibility with media players.

Many devices cannot process Dolby Vision Profile 7 files, including:
- Apple TV 4K (Plex/Infuse)
- Nvidia Shield
- Zidoo players

This causes fallback to HDR10 or playback issues.

### Features

- Web-based interface for easy operation
- Scan directories for Dolby Vision files
- Batch conversion with progress tracking
- Safe mode for problematic files
- Automatic backup creation
- Real-time output streaming

Based on the excellent [dovi_convert](https://github.com/cryptochrome/dovi_convert) script by cryptochrome.

### Checklist

- [x] Template follows CA XML schema
- [x] Docker image is on Docker Hub
- [x] Icon is hosted and accessible
- [x] Support/Project URLs are valid