### PR TITLE
Update shrinkray.xml with GPU passthrough instructions

### DIFF
--- a/templates/shrinkray.xml
+++ b/templates/shrinkray.xml
@@ -25,7 +25,7 @@
 
   <!-- Volumes -->
   <Config Name="Config" Target="/config" Default="/mnt/user/appdata/shrinkray" Mode="rw" Type="Path" Description="Configuration directory" Display="always" Required="true"/>
-  <Config Name="Media" Target="/media" Default="/mnt/user/" Mode="rw" Type="Path" Description="Media library to transcode" Display="always" Required="true"/>
+  <Config Name="Media" Target="/media" Default="" Mode="rw" Type="Path" Description="Media library to transcode" Display="always-hide" Required="true"/>
   <Config Name="Temp" Target="/temp" Default="" Mode="rw" Type="Path" Description="(Optional) Fast storage for temp files during transcode" Display="always" Required="false"/>
 
   <!-- Environment Variables -->


### PR DESCRIPTION
## Summary
- Added GPU setup instructions to Overview (Intel/AMD and NVIDIA)
- Added Requires field to warn about GPU passthrough recommendation  
- Added ReadMe link to GitHub documentation

## Details
Users were having trouble figuring out how to enable hardware acceleration. This update adds clear instructions directly in the template's Overview section so users see the GPU setup steps during installation.

**Intel/AMD:** `--device=/dev/dri:/dev/dri`
**NVIDIA:** `--runtime=nvidia --gpus all`