### PR TITLE
Update Shoko Server registry URL to ghcr

### DIFF
--- a/templates/shoko-server.xml
+++ b/templates/shoko-server.xml
@@ -2,12 +2,12 @@
 <Container version="2">
   <Name>shoko-server</Name>
   <Date>2022-08-03</Date>
-  <Repository>shokoanime/server:latest</Repository>
+  <Repository>ghcr.io/shokoanime/server:latest</Repository>
   <Branch>
     <Tag>daily</Tag>
     <TagDescription>The daily branch includes the latest updates and may break database compatability with prior versions, you will not be able to revert without a database backup</TagDescription>
   </Branch>
-  <Registry>https://hub.docker.com/r/shokoanime/server/</Registry>
+  <Registry>https://github.com/ShokoAnime/ShokoServer/pkgs/container/server/</Registry>
   <Beta>False</Beta>
   <ExtraSearchTerms>anime japanese media anidb myanimelist avidump plex jellyfin metadata</ExtraSearchTerms>
   <Category>MediaApp:Video</Category>


### PR DESCRIPTION
I'm from the Shoko team. We are gradually moving away from Docker Hub to GHCR.
At this point, it's not definite that the images will ever go away from Docker Hub, but as we had a few issues with them in the past, we decided it's better to keep GHCR as the "main" way to get the image going forward.
Just wanted to update the registry URL for the same.

We made the same change in our docs as well:
https://docs.shokoanime.com/getting-started/installing-shoko-server#docker-compose-builder