### PR TITLE
Update shrinkray.xml with improved GPU setup and NVIDIA support

### DIFF
--- a/templates/shrinkray.xml
+++ b/templates/shrinkray.xml
@@ -24,8 +24,8 @@
   <Config Name="WebUI Port" Target="8080" Default="8080" Mode="tcp" Type="Port" Description="Web interface port" Display="always" Required="true"/>
 
   <!-- Volumes -->
-  <Config Name="Config" Target="/config" Default="/mnt/user/appdata/shrinkray" Mode="rw" Type="Path" Description="Configuration directory" Display="always" Required="true"/>
-  <Config Name="Media" Target="/media" Default="" Mode="rw" Type="Path" Description="Media library to transcode" Display="always" Required="true"/>
+  <Config Name="Config" Target="/config" Default="/mnt/user/appdata/shrinkray" Mode="rw" Type="Path" Description="Configuration directory" Display="always-hide" Required="true"/>
+  <Config Name="Media" Target="/media" Default="" Mode="rw" Type="Path" Description="Media library to transcode" Display="always-hide" Required="true"/>
   <Config Name="Temp" Target="/temp" Default="" Mode="rw" Type="Path" Description="(Optional) Fast storage for temp files during transcode" Display="always" Required="false"/>
 
   <!-- Environment Variables -->


### PR DESCRIPTION
## Summary
- Rewrote GPU passthrough instructions with clearer per-vendor formatting (Intel/AMD vs NVIDIA)
- Added `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` environment variables for NVIDIA GPU support

## Context
These changes improve the Shrinkray template to make GPU-accelerated transcoding easier to set up, especially for NVIDIA users who need the runtime and device visibility variables configured.