### PR TITLE
Add Patreon Credits Generator template

### DIFF
--- a/templates/patreon-credits.xml
+++ b/templates/patreon-credits.xml
@@ -12,7 +12,6 @@
   <WebUI>http://[IP]:[PORT:8787]</WebUI>
   <Icon>https://raw.githubusercontent.com/mscrnt/patreon-credits/main/icon.png</Icon>
   <TemplateURL>https://raw.githubusercontent.com/selfhosters/unRAID-CA-templates/master/templates/patreon-credits.xml</TemplateURL>
-  <Description>Patreon Credits Generator creates scrolling end-credits videos for YouTube creators. Connect your Patreon account to automatically fetch supporter names, or paste names manually. Configure fonts, colors, column layouts, header text, and resolution (720p/1080p/4K) through the web UI. Browse and manage generated videos in the built-in gallery. Videos are rendered as MP4 using FFmpeg. Also includes a REST API with Swagger documentation.</Description>
   <DonateText>Buy Me a Coffee</DonateText>
   <DonateLink>https://buymeacoffee.com/mscrnt</DonateLink>
   <Config Name="WebUI Port" Target="8787" Default="8787" Mode="tcp" Description="Port for the web interface." Type="Port" Display="always" Required="true" Mask="false"/>


### PR DESCRIPTION
## New Template: Patreon Credits Generator

**Docker Hub:** https://hub.docker.com/r/mscrnt/patreon-credits
**GitHub:** https://github.com/mscrnt/patreon-credits

### What it does

Generates professional scrolling end-credits videos (MP4) for YouTube content creators, featuring their Patreon supporters. Users can fetch patron names from the Patreon API or paste names manually.

### Key features

- Web-based UI for configuring fonts, colors, layout, and resolution
- 35 bundled font families with CJK/international character support
- 720p, 1080p, and 4K output
- 1–5 column layouts with customizable styling
- REST API with Swagger documentation
- Adobe Premiere Pro plugin for direct timeline integration
- Dummy data mode for testing without Patreon credentials

### Template configuration

| Setting | Type | Description |
|---------|------|-------------|
| WebUI Port | Port | `8787` (default) |
| Output Directory | Path | Generated video storage |
| Patreon Token | Variable | Creator Access Token (optional, masked) |
| Campaign ID | Variable | Patreon Campaign ID (optional) |
| Use Dummy Data | Variable | Toggle for testing mode |

### Screenshots

<p align="center">
  <img src="https://raw.githubusercontent.com/mscrnt/patreon-credits/main/docs/main_page.png" width="600"><br>
  <em>Web UI — configure styling, fonts, colors, and layout</em>
</p>

<p align="center">
  <img src="https://raw.githubusercontent.com/mscrnt/patreon-credits/main/docs/credits.png" width="600"><br>
  <em>Generated scrolling credits video</em>
</p>