### PR TITLE
youtubedl-material: Update repository and project links in XML template

### DIFF
--- a/templates/youtubedl-material.xml
+++ b/templates/youtubedl-material.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>youtube-dl material</Name>
-  <Repository>tzahi12345/youtubedl-material:nightly</Repository>
-  <Registry>https://hub.docker.com/r/tzahi12345/youtubedl-material/</Registry>
-  <Category>Downloaders: MediaApp:Video MediaApp:Music Status:Beta</Category>
+  <Repository>voc0der/youtubedl-material:nightly</Repository>
+  <Registry>https://hub.docker.com/r/voc0der/youtubedl-material/</Registry>
+  <Category>Downloaders: MediaApp:Video MediaApp:Music</Category>
   <Network>bridge</Network>
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/</Support>
-  <Project>https://github.com/Tzahi12345/YoutubeDL-Material</Project>
+  <Project>https://github.com/voc0der/YoutubeDL-Material</Project>
   <Overview>YoutubeDL-Material is a self-hosted youtube-dl Server with a modern Material-based GUI and the capability to apply advanced configurations, like setting your own download paths based on rules.&#xD;
 &#xD;
 It is designed to be more customizable than the alternatives out there.&#xD;


### PR DESCRIPTION
Original repo was abandoned and the app recently became unusable due to YT changes.
This fork has taken it over and fixed it. 
