### PR TITLE
Add Kometizarr — Plex rating overlays & collection management

### DIFF
--- a/templates/kometizarr-backend.xml
+++ b/templates/kometizarr-backend.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>kometizarr-backend</Name>
+  <Repository>ghcr.io/p2chill/kometizarr-backend:latest</Repository>
+  <Registry>https://github.com/P2Chill/kometizarr/pkgs/container/kometizarr-backend</Registry>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/P2Chill/kometizarr/discussions</Support>
+  <Project>https://github.com/P2Chill/kometizarr</Project>
+  <Overview>
+    Kometizarr Backend — automatically adds multi-source rating overlays (TMDB, IMDb, Rotten Tomatoes) to your Plex posters.
+
+    Install kometizarr-backend first, then install kometizarr-frontend.
+
+    Requires API keys from: TMDB (free), MDBList (free), and optionally OMDb.
+    Get your Plex token: https://support.plex.tv/articles/204059436
+  </Overview>
+  <Category>MediaApp:Other Tools:</Category>
+  <WebUI>http://[IP]:[PORT:8000]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/P2Chill/kometizarr/main/unraid/kometizarr-backend.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/P2Chill/kometizarr/main/docs/icon.png</Icon>
+  <ExtraDescription>Install kometizarr-backend FIRST, then install kometizarr-frontend. The backend handles all processing and exposes the API on port 8000.</ExtraDescription>
+  <Date>2026-02-23</Date>
+
+  <!-- Ports -->
+  <Config Name="API Port" Target="8000" Default="8000" Mode="tcp"
+    Type="Port" Display="always" Required="true" Mask="false"
+    Description="Backend API port. Also used for the Plex webhook endpoint (/webhook/plex)."/>
+
+  <!-- Volumes -->
+  <Config Name="Poster Backups" Target="/backups" Default="/mnt/user/appdata/kometizarr/backups" Mode="rw"
+    Type="Path" Display="always" Required="true" Mask="false"
+    Description="Persistent storage for original poster backups. Keep this safe — it is required for restoring originals."/>
+
+  <Config Name="App Data" Target="/app/kometizarr/data" Default="/mnt/user/appdata/kometizarr/data" Mode="rw"
+    Type="Path" Display="always" Required="true" Mask="false"
+    Description="Persistent storage for Kometizarr settings (cron schedule, webhook config, etc.)."/>
+
+  <!-- Required environment variables -->
+  <Config Name="Plex URL" Target="PLEX_URL" Default="http://192.168.1.x:32400" Mode=""
+    Type="Variable" Display="always" Required="true" Mask="false"
+    Description="URL to your Plex Media Server. Use the LAN IP, not localhost."/>
+
+  <Config Name="Plex Token" Target="PLEX_TOKEN" Default="" Mode=""
+    Type="Variable" Display="always" Required="true" Mask="true"
+    Description="Your Plex authentication token. See https://support.plex.tv/articles/204059436 for how to find it."/>
+
+  <Config Name="TMDB API Key" Target="TMDB_API_KEY" Default="" Mode=""
+    Type="Variable" Display="always" Required="true" Mask="true"
+    Description="The Movie Database API key (free). Get one at https://www.themoviedb.org/settings/api"/>
+
+  <Config Name="MDBList API Key" Target="MDBLIST_API_KEY" Default="" Mode=""
+    Type="Variable" Display="always" Required="true" Mask="true"
+    Description="MDBList API key for Rotten Tomatoes scores (free). Get one at https://mdblist.com/"/>
+
+  <!-- Optional environment variables -->
+  <Config Name="OMDb API Key" Target="OMDB_API_KEY" Default="" Mode=""
+    Type="Variable" Display="advanced" Required="false" Mask="true"
+    Description="Optional: OMDb API key for IMDb ratings. Get one at https://www.omdbapi.com/"/>
+</Container>

--- a/templates/kometizarr-frontend.xml
+++ b/templates/kometizarr-frontend.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>kometizarr-frontend</Name>
+  <Repository>ghcr.io/p2chill/kometizarr-frontend:latest</Repository>
+  <Registry>https://github.com/P2Chill/kometizarr/pkgs/container/kometizarr-frontend</Registry>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/P2Chill/kometizarr/discussions</Support>
+  <Project>https://github.com/P2Chill/kometizarr</Project>
+  <Overview>
+    Kometizarr Frontend — Web UI for Kometizarr (rating overlays and collection management for Plex).
+
+    Install kometizarr-backend FIRST, then install this container.
+
+    The frontend proxies API requests to kometizarr-backend. Both containers must be running for the UI to work.
+  </Overview>
+  <Category>MediaApp:Other Tools:</Category>
+  <WebUI>http://[IP]:[PORT:3001]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/P2Chill/kometizarr/main/unraid/kometizarr-frontend.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/P2Chill/kometizarr/main/docs/icon.png</Icon>
+  <ExtraDescription>Requires kometizarr-backend to be installed and running first. The --link flag in Extra Parameters connects this container to the backend.</ExtraDescription>
+  <ExtraParams>--link kometizarr-backend:backend</ExtraParams>
+  <Date>2026-02-23</Date>
+
+  <!-- Ports -->
+  <Config Name="Web UI Port" Target="80" Default="3001" Mode="tcp"
+    Type="Port" Display="always" Required="true" Mask="false"
+    Description="Port for the Kometizarr web interface. Open http://[IP]:3001 after starting."/>
+</Container>


### PR DESCRIPTION
## Kometizarr

Automatically adds multi-source rating badges (TMDB, IMDb, Rotten Tomatoes Critic + Audience) to Plex movie and TV show posters. Also includes smart collection management (decade, studio, keyword collections).

**GitHub:** https://github.com/P2Chill/kometizarr  
**Docker Hub:** https://hub.docker.com/r/p2chill/kometizarr-backend

### Two containers

- **kometizarr-backend** — FastAPI backend, handles processing and exposes the API + Plex webhook on port 8000
- **kometizarr-frontend** — React/nginx web UI on port 3001, proxies to backend via `--link`

### Install order

1. Install `kometizarr-backend` first (fill in API keys)
2. Install `kometizarr-frontend` — `--link kometizarr-backend:backend` is pre-set in ExtraParams

### Requirements

- Plex Media Server
- TMDB API key (free) — https://www.themoviedb.org/settings/api
- MDBList API key (free) — https://mdblist.com/
- OMDb API key (optional) — https://www.omdbapi.com/

### Support thread

https://github.com/P2Chill/kometizarr/discussions

### Notes

- Images on Docker Hub (`p2chill/`) and GHCR (`ghcr.io/p2chill/`) — templates use GHCR
- Settings persist in the App Data volume (`/app/kometizarr/data`)
- Backups volume stores original posters before overlays are applied