### PR TITLE
forgejo: document rootless image path mapping requirements

### DIFF
--- a/templates/forgejo.xml
+++ b/templates/forgejo.xml
@@ -2,7 +2,7 @@
 <Container version="2">
   <Name>Forgejo</Name>
   <Repository>codeberg.org/forgejo/forgejo:11</Repository>
-  <Requires>This container does not use a rolling tag such as `latest`. To update to the next major version, you will need to manually edit the tag in Repository. More details: https://forgejo.org/faq/#why-is-there-no-latest-tag-for-container-images</Requires>
+  <Requires>This container does not use a rolling tag such as `latest`. To update to the next major version, you will need to manually edit the tag in Repository. More details: https://forgejo.org/faq/#why-is-there-no-latest-tag-for-container-images[br][br]If using a rootless image (tags ending in -rootless), do NOT use the Data Storage Path mapping below. Instead, add two custom path mappings: your host data directory mapped to /var/lib/gitea, and your host config directory mapped to /etc/gitea. Using the standard /data mapping with a rootless image will result in no data being written to the host and data loss on container restart.</Requires>
   <Registry>https://codeberg.org/forgejo/-/packages/container/forgejo/versions</Registry>
   <Network>bridge</Network>
   <Privileged>false</Privileged>


### PR DESCRIPTION
The rootless Forgejo images (tags ending in -rootless) require different container path mappings than the standard image. The existing /data mapping does not work with rootless images — no data is written to the host, leading to data loss on container restart.

Rootless images require two separate mappings:
  - host data dir  → /var/lib/gitea
  - host config dir → /etc/gitea

Added a note to the Requires field so this is visible to users at install time in the Unraid Community Applications GUI before they make a choice about which image tag to use.