### PR TITLE
zf-bridge-unraid: enable 1-tap self-update via docker socket

### DIFF
--- a/templates/zf-bridge-unraid.xml
+++ b/templates/zf-bridge-unraid.xml
@@ -12,15 +12,18 @@
 &#xD;
 First launch: pair with a one-time code from your iOS app, container persists credentials in /app/data and reuses on restart.&#xD;
 &#xD;
-Host network mode is required so the bridge can SSDP-discover Sonos speakers on your LAN. Container runs as non-root user (UID 10001) with --cap-drop ALL — make sure the host data path is chowned 10001:10001.</Overview>
+1-tap updates: the iOS app's Bridges screen surfaces "升级" / "Apply Update" when a new bridge image is published — tap once and the bridge pulls the new image via the mounted docker socket and restarts itself. No SSH or Container Manager interaction needed.&#xD;
+&#xD;
+Host network mode is required so the bridge can SSDP-discover Sonos speakers on your LAN. Container runs as non-root user (UID 10001) with --cap-drop ALL — make sure the host data path is chowned 10001:10001. The docker socket mount and --group-add 281 (Unraid's docker group GID) grant the bridge permission to pull new images for self-update; remove them if you prefer manual updates only.</Overview>
   <Category>HomeAutomation: Other:</Category>
   <TemplateURL>https://raw.githubusercontent.com/kisssam6886/zonefoundry/main/docker/unraid/zf-bridge-unraid.xml</TemplateURL>
   <Icon>https://relay.zonefoundry.dev/icon-512.png</Icon>
-  <ExtraParams>--cap-drop ALL --read-only --tmpfs /tmp:rw,nosuid,nodev,size=16m</ExtraParams>
+  <ExtraParams>--cap-drop ALL --read-only --tmpfs /tmp:rw,nosuid,nodev,size=16m --group-add 281</ExtraParams>
   <Config Name="Relay URL" Target="ZF_RELAY_URL" Default="wss://relay.zonefoundry.dev/ws" Mode="" Description="ZoneFoundry cloud relay WebSocket URL." Type="Variable" Display="always" Required="true" Mask="false">wss://relay.zonefoundry.dev/ws</Config>
   <Config Name="Pair Code (first launch only)" Target="ZF_PAIR_CODE" Default="" Mode="" Description="One-time 6-letter code from your iOS app's Add Bridge screen. Only needed for first launch — once paired, container caches credentials in /app/data and you can clear this field." Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="User ID (override)" Target="ZF_USER_ID" Default="" Mode="" Description="Advanced: explicit user_id from existing pairing (skips pair-code redeem). Leave empty to use pair code instead." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Agent Secret (override)" Target="ZF_AGENT_SECRET" Default="" Mode="" Description="Advanced: explicit secret matching User ID. Leave empty to use pair code instead." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="Connector ID (override)" Target="ZF_CONNECTOR_ID" Default="" Mode="" Description="Advanced: explicit connector identity for multi-bridge users. Leave empty for default-legacy." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Data Volume" Target="/app/data" Default="/mnt/user/appdata/zonefoundry-bridge" Mode="rw" Description="Persistent data: cached pairing credentials. Must be chowned 10001:10001 on host (chown -R 10001:10001 /mnt/user/appdata/zonefoundry-bridge)." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/zonefoundry-bridge</Config>
+  <Config Name="Docker Socket (1-tap update)" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="rw" Description="Mounts the host's docker socket so the bridge can pull and apply its own image updates when you tap '升级' / 'Apply Update' in the iOS app's Bridges screen. Combined with --group-add 281 in Extra Parameters, the non-root bridge user gets permission to talk to Docker. Remove this mount and the --group-add flag if you prefer to update manually via Apply Update on this template." Type="Path" Display="always" Required="false" Mask="false">/var/run/docker.sock</Config>
 </Container>


### PR DESCRIPTION
## Summary
- Adds a `/var/run/docker.sock` Path config (default-on, opt-out) and `--group-add 281` to ExtraParams for `zf-bridge-unraid` so the ZoneFoundry bridge can pull and apply its own image updates from Docker Hub when the user taps "升级" / "Apply Update" in the iOS app's Bridges screen.
- Updates the Overview to describe the 1-tap update flow and the security trade-off, so users know exactly what the new mount does and how to opt out.
- No other behaviour changes — host network mode, non-root UID 10001, `--cap-drop ALL`, `--read-only`, and the existing data volume are all unchanged.

## Why
The bridge ships with an in-binary update handler (v0.1.43+) that talks to the docker socket via the standard Unix HTTP API, streams pull progress over WebSocket back to the relay, and SIGTERMs itself once the new image is pulled so Docker's `restart_policy=always` recreates the container with the fresh image. Without the socket mount, `Apply Update` from the iOS app fails loud with "docker socket not mounted" — this PR closes that gap for new CA installs so the 1-tap update path works out of the box.

## Test plan
- [x] Validated the XML structure visually and against existing CA templates that mount the docker socket
- [x] Confirmed the bridge's apply_update code path handles missing socket gracefully (returns explicit `update_status: error` message rather than silent fail)
- [ ] Fresh install via Community Applications on Unraid — pair, run, then trigger Apply Update from iOS app and confirm new image is pulled and bridge restarts