### PR TITLE
Update kopia.xml

### DIFF
--- a/templates/kopia.xml
+++ b/templates/kopia.xml
@@ -14,7 +14,7 @@ To run this container, you must create a htpasswd file (either via command line 
   <Category>Backup: Cloud:</Category>
   <WebUI>http://[IP]:[PORT:51515]</WebUI>
   <TemplateURL>https://github.com/selfhosters/unRAID-CA-templates/blob/master/templates/kopia.xml</TemplateURL>
-  <Icon>https://raw.githubusercontent.com/kopia/kopia/master/icons/kopia.svg</Icon>
+  <Icon>https://raw.githubusercontent.com/kopia/kopia/refs/heads/master/app/assets/icon.ico</Icon>
   <PostArgs>server start --insecure --htpasswd-file /app/config/htpasswd --address 0.0.0.0:51515 --server-username=YOUR-USERNAME</PostArgs>
   <Config Name="Repository password" Target="KOPIA_PASSWORD" Default="" Mode="" Description="Container Variable: KOPIA_PASSWORD" Type="Variable" Display="always" Required="true" Mask="true"/>
   <Config Name="Port" Target="51515" Default="51515" Mode="tcp" Description="Container Port: 51515" Type="Port" Display="always" Required="true" Mask="false">51515</Config>


### PR DESCRIPTION
The .svg icon file does not show correctly in the Docker tab in Unraid. Replacing it with "https://raw.githubusercontent.com/kopia/kopia/refs/heads/master/app/assets/icon.ico" does work.