### PR TITLE
fix(navidrome): ND_SCANSCHEDULE was renamed to ND_SCANNER_SCHEDULE

### DIFF
--- a/templates/navidrome.xml
+++ b/templates/navidrome.xml
@@ -13,7 +13,7 @@
    <Config Name="WebUI" Target="4533" Default="" Mode="tcp" Description="Container Port: 4533" Type="Port" Display="always" Required="false" Mask="false">4533</Config>
    <Config Name="Appdata" Target="/data" Default="" Mode="rw" Description="Container Path: /data" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/navidrome</Config>
    <Config Name="Music" Target="/music" Default="" Mode="rw" Description="Container Path: /music" Type="Path" Display="always" Required="false" Mask="false"/>
-   <Config Name="Scan Schedule" Target="ND_SCANSCHEDULE" Default="" Mode="" Description="Container Variable: ND_SCANSCHEDULE" Type="Variable" Display="always" Required="false" Mask="false">1m</Config>
+   <Config Name="Scan Schedule" Target="ND_SCANNER_SCHEDULE" Default="" Mode="" Description="Container Variable: ND_SCANNER_SCHEDULE" Type="Variable" Display="always" Required="false" Mask="false">@every 1m</Config>
    <Config Name="Log Level" Target="ND_LOGLEVEL" Default="" Mode="" Description="Container Variable: ND_LOGLEVEL" Type="Variable" Display="always" Required="false" Mask="false">info</Config>
    <Config Name="Timeout" Target="ND_SESSIONTIMEOUT" Default="" Mode="" Description="Container Variable: ND_SESSIONTIMEOUT" Type="Variable" Display="always" Required="false" Mask="false">24h</Config>
    <Config Name="BaseURL" Target="ND_BASEURL" Default="" Mode="" Description="Container Variable: ND_BASEURL" Type="Variable" Display="always" Required="false" Mask="false"/>


### PR DESCRIPTION
Fixes #687.

Navidrome renamed this option in v0.55.0 (2025-02-28), no backward-compatibility alias. On current Navidrome (0.63.2) `ND_SCANSCHEDULE` is silently ignored, so the periodic scan never runs on an unmodified install of this template, the scanner schedule defaults to disabled.

One-line change:
- `ND_SCANSCHEDULE` → `ND_SCANNER_SCHEDULE`
- Value `1m` → `@every 1m` (a bare `1m` isn't a valid cron expression or `@every` duration, it wouldn't parse either way)

Reference: the rename is listed under v0.55.0's changed configuration options, and the current docs document only `ND_SCANNER_SCHEDULE`.